### PR TITLE
use AMREX_HOME if it exists

### DIFF
--- a/GNUmakefile
+++ b/GNUmakefile
@@ -1,7 +1,7 @@
 ### ------------------------------------------------------
 ### GNUmakefile for Amrvis
 ### ------------------------------------------------------
-AMREX_HOME = ../amrex
+AMREX_HOME ?= ../amrex
 
 PRECISION = FLOAT
 PRECISION = DOUBLE


### PR DESCRIPTION
this change respects a user's `AMREX_HOME` variable.  Without this, the code needs to be in an immediate subdirectory of `amrex` to build.