### PR TITLE
Fix ProfApp: Implicit amrex::

### DIFF
--- a/ProfApp.cpp
+++ b/ProfApp.cpp
@@ -65,6 +65,8 @@ const int plotAreaHeight(342);
 const int funcListHeight(600);
 const int funcListWidth(850);
 
+using namespace amrex;
+
 void CollectMProfStats(std::map<std::string, BLProfiler::ProfStats> &mProfStats,
                        const Vector<Vector<BLProfStats::FuncStat> > &funcStats,
                        const Vector<std::string> &fNames,


### PR DESCRIPTION
The file `ProfApp.cpp` implicitly assumes the `amrex::` namespace is used in multiple locations. This makes it available to fix multiple compliation errors in 2D with profiling on Ubuntu with GCC.