### PR TITLE
Add initplanesreal option

### DIFF
--- a/AmrPicture.cpp
+++ b/AmrPicture.cpp
@@ -100,13 +100,22 @@ AmrPicture::AmrPicture(GraphicsAttributes *gaptr,
     dataSize[ilev]  = dataSizeH[ilev] * dataSizeV[ilev];  // for a picture (slice).
   }
 
-  if(AVGlobals::GivenInitialPlanes()) {
+  if(AVGlobals::GivenInitialPlanes() || AVGlobals::GivenInitialPlanesReal()) {
     BL_ASSERT(BL_SPACEDIM == 3);
+    IntVect initialplanes;
+    if (AVGlobals::GivenInitialPlanes()) {
+        initialplanes = AVGlobals::GetInitialPlanes();
+    } else if (AVGlobals::GivenInitialPlanesReal()) {
+        auto const location = AVGlobals::GetInitialPlanesReal();
+        IntVect ivLoc;
+        int ivLevel;
+        amrData.IntVectFromLocation(pltAppStatePtr->FinestLevel(), location, ivLoc, ivLevel, initialplanes);
+    }
     int coarsenCRR = amrex::CRRBetweenLevels(maxAllowableLevel,
                                                  pltAppStatePtr->FinestLevel(),
                                                  amrData.RefRatio());
-    int tempSliceV = AVGlobals::GetInitialPlanes()[Amrvis::XDIR];  // at finest lev
-    int tempSliceH = AVGlobals::GetInitialPlanes()[Amrvis::YDIR];  // at finest lev
+    int tempSliceV = initialplanes[Amrvis::XDIR];  // at finest lev
+    int tempSliceH = initialplanes[Amrvis::YDIR];  // at finest lev
     tempSliceV /= coarsenCRR;
     tempSliceH /= coarsenCRR;
     tempSliceH = subDomain[maxAllowableLevel].bigEnd(Amrvis::YDIR) - tempSliceH;
@@ -121,7 +130,7 @@ AmrPicture::AmrPicture(GraphicsAttributes *gaptr,
     subcutY = hLine;
     subcut2ndY = hLine;
 
-    int tempSlice = AVGlobals::GetInitialPlanes()[Amrvis::YZ - myView];  // at finest lev
+    int tempSlice = initialplanes[Amrvis::YZ - myView];  // at finest lev
     tempSlice /= coarsenCRR;
     slice = amrex::max(std::min(tempSlice,
                     subDomain[maxAllowableLevel].bigEnd(Amrvis::YZ-myView)), 
@@ -245,8 +254,17 @@ AmrPicture::AmrPicture(int view, GraphicsAttributes *gaptr,
                       subDomain[maxAllowableLevel].bigEnd(Amrvis::YZ-myView)), 
                       subDomain[maxAllowableLevel].smallEnd(Amrvis::YZ-myView));
     } else {
-      if(AVGlobals::GivenInitialPlanes()) {
-	int tempSlice = AVGlobals::GetInitialPlanes()[Amrvis::YZ - myView];  // finest lev
+      if(AVGlobals::GivenInitialPlanes() || AVGlobals::GivenInitialPlanesReal()) {
+        IntVect initialplanes;
+        if (AVGlobals::GivenInitialPlanes()) {
+            initialplanes = AVGlobals::GetInitialPlanes();
+        } else if (AVGlobals::GivenInitialPlanesReal()) {
+            auto const location = AVGlobals::GetInitialPlanesReal();
+            IntVect ivLoc;
+            int ivLevel;
+            amrData.IntVectFromLocation(pltAppStatePtr->FinestLevel(), location, ivLoc, ivLevel, initialplanes);
+        }
+        int tempSlice = initialplanes[Amrvis::YZ - myView];  // finest lev
         int coarsenCRR = amrex::CRRBetweenLevels(maxAllowableLevel,
                                                      pltAppStatePtr->FinestLevel(),
                                                      amrData.RefRatio());
@@ -257,8 +275,8 @@ AmrPicture::AmrPicture(int view, GraphicsAttributes *gaptr,
 
         int tempSliceV, tempSliceH;
         if(myView==Amrvis::XY) {
-          tempSliceV = AVGlobals::GetInitialPlanes()[Amrvis::XDIR];  // at finest lev
-          tempSliceH = AVGlobals::GetInitialPlanes()[Amrvis::YDIR];  // at finest lev
+          tempSliceV = initialplanes[Amrvis::XDIR];  // at finest lev
+          tempSliceH = initialplanes[Amrvis::YDIR];  // at finest lev
           tempSliceV /= coarsenCRR;
           tempSliceH /= coarsenCRR;
           tempSliceH = subDomain[maxAllowableLevel].bigEnd(Amrvis::YDIR) - tempSliceH;
@@ -269,8 +287,8 @@ AmrPicture::AmrPicture(int view, GraphicsAttributes *gaptr,
                           subDomain[maxAllowableLevel].bigEnd(Amrvis::YDIR)), 
                           subDomain[maxAllowableLevel].smallEnd(Amrvis::YDIR));
         } else if(myView==Amrvis::XZ) {
-          tempSliceV = AVGlobals::GetInitialPlanes()[Amrvis::XDIR];  // at finest lev
-          tempSliceH = AVGlobals::GetInitialPlanes()[Amrvis::ZDIR];  // at finest lev
+          tempSliceV = initialplanes[Amrvis::XDIR];  // at finest lev
+          tempSliceH = initialplanes[Amrvis::ZDIR];  // at finest lev
           tempSliceV /= coarsenCRR;
           tempSliceH /= coarsenCRR;
           tempSliceH = subDomain[maxAllowableLevel].bigEnd(Amrvis::ZDIR) - tempSliceH;
@@ -281,8 +299,8 @@ AmrPicture::AmrPicture(int view, GraphicsAttributes *gaptr,
                           subDomain[maxAllowableLevel].bigEnd(Amrvis::ZDIR)), 
                           subDomain[maxAllowableLevel].smallEnd(Amrvis::ZDIR));
         } else {
-          tempSliceV = AVGlobals::GetInitialPlanes()[Amrvis::YDIR];  // at finest lev
-          tempSliceH = AVGlobals::GetInitialPlanes()[Amrvis::ZDIR];  // at finest lev
+          tempSliceV = initialplanes[Amrvis::YDIR];  // at finest lev
+          tempSliceH = initialplanes[Amrvis::ZDIR];  // at finest lev
           tempSliceV /= coarsenCRR;
           tempSliceH /= coarsenCRR;
           tempSliceH = subDomain[maxAllowableLevel].bigEnd(Amrvis::ZDIR) - tempSliceH;

--- a/Docs/Amrvis.tex
+++ b/Docs/Amrvis.tex
@@ -83,6 +83,7 @@ amrvis3d [-help]
        [-makeswf_value]
        [-valuemodel]
        [-initplanes xp yp zp]
+       [-initplanesreal xp yp zp]
        [-useminmax min max]
        [<filename(s)>]
 
@@ -128,7 +129,8 @@ amrvis3d [-help]
                      note:  works in batch mode.
   -makeswf_value     same as above, with value model rendering.
   -valuemodel        start with the value model for rendering.
-  -initplanes xp yp zp     set initial planes
+  -initplanes xp yp zp     set initial planes in finest level grid cells
+  -initplanesreal xp yp zp set initial planes in real units
   -useminmax min max       use min and max as the global min max values
   <filename(s)>      must be included if box is specified.
 \end{verbatim}

--- a/GlobalUtilities.H
+++ b/GlobalUtilities.H
@@ -87,6 +87,8 @@ namespace AVGlobals {
   int  GetFabOutFormat();
   bool GivenInitialPlanes();
   amrex::IntVect GetInitialPlanes();
+  bool GivenInitialPlanesReal();
+  amrex::Vector< Real > GetInitialPlanesReal();
   bool IsProfDirName(const std::string &pdname);
 
   // -------------------- cartGrid functions

--- a/GlobalUtilities.cpp
+++ b/GlobalUtilities.cpp
@@ -62,6 +62,8 @@ bool bShowBody(true);
 Real bodyOpacity(0.05);
 bool givenInitialPlanes(false);
 IntVect ivInitialPlanes;
+bool givenInitialPlanesReal(false);
+Vector< Real > ivInitialPlanesReal;
 AVGlobals::ENUserVectorNames givenUserVectorNames(AVGlobals::enUserNone);
 Vector<string> userVectorNames(BL_SPACEDIM);
 bool newPltSet(false);
@@ -478,6 +480,15 @@ void AVGlobals::GetDefaults(const string &defaultsFile) {
         ivInitialPlanes.setVal(Amrvis::ZDIR, tempZ);
         givenInitialPlanes = true;
       }
+      else if(strcmp(defaultString, "initplanesreal") == 0) {
+        float tempX, tempY, tempZ;
+        sscanf(buffer, "%s%e%e%e", defaultString, &tempX, &tempY, &tempZ);
+        ivInitialPlanesReal.resize(BL_SPACEDIM);
+        ivInitialPlanesReal[Amrvis::XDIR] = tempX;
+        ivInitialPlanesReal[Amrvis::YDIR] = tempY;
+        ivInitialPlanesReal[Amrvis::ZDIR] = tempZ;
+        givenInitialPlanesReal = true;
+      }
 #endif
       else if(strcmp(defaultString, "setvelnames") == 0) {
 #if (BL_SPACEDIM == 2)
@@ -633,6 +644,8 @@ void AVGlobals::ParseCommandLine(int argc, char *argv[]) {
   char clbz[32];
   char clPlaneX[32], clPlaneY[32], clPlaneZ[32];
   bool givenInitialPlanesOnComline(false);
+  char clPlaneXReal[32], clPlaneYReal[32], clPlaneZReal[32];
+  bool givenInitialPlanesRealOnComline(false);
 #endif
 
   givenFilename = false;
@@ -931,6 +944,19 @@ void AVGlobals::ParseCommandLine(int argc, char *argv[]) {
       i += 3;
       givenInitialPlanes = true;
       givenInitialPlanesOnComline = true;
+    } else if(strcmp(argv[i], "-initplanesreal") == 0) {
+      if(argc-1<i+1 || ! strcpy(clPlaneXReal, argv[i+1])) {
+        PrintUsage(argv[0]);
+      }
+      if(argc-1<i+2 || ! strcpy(clPlaneYReal, argv[i+2])) {
+        PrintUsage(argv[0]);
+      }
+      if(argc-1<i+3 || ! strcpy(clPlaneZReal, argv[i+3])) {
+        PrintUsage(argv[0]);
+      }
+      i += 3;
+      givenInitialPlanesReal = true;
+      givenInitialPlanesRealOnComline = true;
 #endif
     } else if(strcmp(argv[i],"-palette") == 0) {
       PltApp::SetDefaultPalette(argv[i+1]);
@@ -1095,6 +1121,12 @@ void AVGlobals::ParseCommandLine(int argc, char *argv[]) {
     ivInitialPlanes.setVal(Amrvis::YDIR, atoi(clPlaneY));
     ivInitialPlanes.setVal(Amrvis::ZDIR, atoi(clPlaneZ));
   }
+  if(givenInitialPlanesRealOnComline) {
+    ivInitialPlanesReal.resize(BL_SPACEDIM);
+    ivInitialPlanesReal[Amrvis::XDIR] = atof(clPlaneXReal);
+    ivInitialPlanesReal[Amrvis::YDIR] = atof(clPlaneYReal);
+    ivInitialPlanesReal[Amrvis::ZDIR] = atof(clPlaneZReal);
+  }
 #endif
 
 
@@ -1185,6 +1217,9 @@ void AVGlobals::GetSpecifiedMinMax(Real &specifiedmin, Real &specifiedmax) {
 
 bool AVGlobals::GivenInitialPlanes() { return givenInitialPlanes; }
 IntVect AVGlobals::GetInitialPlanes() { return ivInitialPlanes; }
+
+bool AVGlobals::GivenInitialPlanesReal() { return givenInitialPlanesReal; }
+Vector <Real>  AVGlobals::GetInitialPlanesReal() { return ivInitialPlanesReal; }
 
 // -------------------------------------------------------------------
 /*int AVGlobals::CRRBetweenLevels(int fromlevel, int tolevel,


### PR DESCRIPTION
This adds a feature that I've wanted for some time but finally got to add it. This allows specifying the initial planes of the visualization in real units rather that only in grid cell units. I frequently do visualization of output from simulations with different levels of refinement so I would have to continually change the values for `initplanes` since they depend on the highest level of resolution. With my change, I can specify the planes in real units (i.e. centimeters) and it will start with the appropriate plane independent of the level of resolution.

Note that this change uses `AmrData::IntVectFromLocation`. For this to work, a change is needed in amrex (Src/Extern/amrdata/AMReX_AmrData.H) specifying that routine as `const`. This is PR #2789 in Amrex.