### PR TITLE
avoid grabbing X server when rubberbanding

### DIFF
--- a/PltApp.H
+++ b/PltApp.H
@@ -214,6 +214,10 @@ private:
   XEvent	nextEvent;
   int 		rWidth, rHeight, rStartX, rStartY;
   Cursor	cursor;
+  
+  // double buffering for rubber band
+  Pixmap	rubberBandBackup;
+  Pixmap	rubberBandBuffer;
 
   static string defaultPaletteString, initialDerived, initialFormatString;
   static string defaultLightingFilename;
@@ -343,40 +347,6 @@ private:
 };
 
 
-// -------------------------------------------------------------------
-class AVXGrab {
-  public:
-    AVXGrab(Display *display) : bIsGrabbed(true), cachedDisplay(display) {
-      XSync(cachedDisplay, False);
-      XGrabServer(display);
-      XSync(cachedDisplay, False);
-    }
-
-    ~AVXGrab() {
-      if(bIsGrabbed) {
-        std::cout << "_______in ~AVXGrab:  implicit ungrab." << std::endl;
-      }
-      XUngrabServer(cachedDisplay);
-      XSync(cachedDisplay, False);
-      bIsGrabbed = false;
-    }
-
-    void ExplicitUngrab() {
-      if(bIsGrabbed == false) {
-        std::cout << "_______in AVXGrab::ExplicitUngrab:  server not grabbed."
-                  << std::endl;
-      }
-      XUngrabServer(cachedDisplay);
-      XSync(cachedDisplay, False);
-      bIsGrabbed = false;
-    }
-
-  private:
-    AVXGrab();  // not implemented
-    bool bIsGrabbed;
-    Display *cachedDisplay;
-};
-// -------------------------------------------------------------------
 
 
 void	SubregionPltApp(Widget toplevel, const amrex::Box &region, const amrex::IntVect &offset,

--- a/PltApp.cpp
+++ b/PltApp.cpp
@@ -3720,7 +3720,7 @@ void PltApp::DoRubberBanding(Widget, XtPointer client_data, XtPointer call_data)
 #if (BL_SPACEDIM == 3)
 	// Double buffering for additional 3D planes
 	switch (V) {
-	case Amrvis::ZPLANE:
+	case Amrvis::ZPLANE: {
 	  // Update YPLANE
 	  XCopyArea(display, planeBackup[Amrvis::YPLANE], planeBuffer[Amrvis::YPLANE], planeGC[Amrvis::YPLANE], 
 	            0, 0, amrPicturePtrArray[Amrvis::YPLANE]->ImageSizeH(), amrPicturePtrArray[Amrvis::YPLANE]->ImageSizeV(), 0, 0);
@@ -3742,8 +3742,9 @@ void PltApp::DoRubberBanding(Widget, XtPointer client_data, XtPointer call_data)
 	  XCopyArea(display, planeBuffer[Amrvis::XPLANE], amrPicturePtrArray[Amrvis::XPLANE]->PictureWindow(), planeGC[Amrvis::XPLANE], 
 	            0, 0, amrPicturePtrArray[Amrvis::XPLANE]->ImageSizeH(), amrPicturePtrArray[Amrvis::XPLANE]->ImageSizeV(), 0, 0);
 	  break;
+	}
 	  
-	case Amrvis::YPLANE:
+	case Amrvis::YPLANE: {
 	  // Update ZPLANE
 	  XCopyArea(display, planeBackup[Amrvis::ZPLANE], planeBuffer[Amrvis::ZPLANE], planeGC[Amrvis::ZPLANE], 
 	            0, 0, amrPicturePtrArray[Amrvis::ZPLANE]->ImageSizeH(), amrPicturePtrArray[Amrvis::ZPLANE]->ImageSizeV(), 0, 0);
@@ -3764,10 +3765,11 @@ void PltApp::DoRubberBanding(Widget, XtPointer client_data, XtPointer call_data)
 	  XCopyArea(display, planeBuffer[Amrvis::XPLANE], amrPicturePtrArray[Amrvis::XPLANE]->PictureWindow(), planeGC[Amrvis::XPLANE], 
 	            0, 0, amrPicturePtrArray[Amrvis::XPLANE]->ImageSizeH(), amrPicturePtrArray[Amrvis::XPLANE]->ImageSizeV(), 0, 0);
 	  break;
+	}
 	  
-	default: // Amrvis::XPLANE
+	default: { // Amrvis::XPLANE
 	  // Update ZPLANE
-	  rStartPlane = (anchorX < newX) ? newX : anchorX;
+	  int rStartPlane = (anchorX < newX) ? newX : anchorX;
 	  XCopyArea(display, planeBackup[Amrvis::ZPLANE], planeBuffer[Amrvis::ZPLANE], planeGC[Amrvis::ZPLANE], 
 	            0, 0, amrPicturePtrArray[Amrvis::ZPLANE]->ImageSizeH(), amrPicturePtrArray[Amrvis::ZPLANE]->ImageSizeV(), 0, 0);
 	  XSetForeground(display, planeGC[Amrvis::ZPLANE], pltPaletteptr->makePixel(120));
@@ -3786,6 +3788,8 @@ void PltApp::DoRubberBanding(Widget, XtPointer client_data, XtPointer call_data)
 	                std::abs(finishcutX[Amrvis::YPLANE]-startcutX[Amrvis::YPLANE]), rHeight);
 	  XCopyArea(display, planeBuffer[Amrvis::YPLANE], amrPicturePtrArray[Amrvis::YPLANE]->PictureWindow(), planeGC[Amrvis::YPLANE], 
 	            0, 0, amrPicturePtrArray[Amrvis::YPLANE]->ImageSizeH(), amrPicturePtrArray[Amrvis::YPLANE]->ImageSizeV(), 0, 0);
+	  break;
+	}
 	}
 #endif
 	rectDrawn = true;

--- a/PltApp.cpp
+++ b/PltApp.cpp
@@ -3632,9 +3632,16 @@ void PltApp::DoRubberBanding(Widget, XtPointer client_data, XtPointer call_data)
             0, 0, bufferWidth, bufferHeight, 0, 0);
 
   // Declare 3D plane variables (needed for cleanup scope)
-  Pixmap planeBackup[amrex::Amrvis::NPLANES] = {None, None, None};
-  Pixmap planeBuffer[amrex::Amrvis::NPLANES] = {None, None, None}; 
-  GC planeGC[amrex::Amrvis::NPLANES] = {None, None, None};
+  Pixmap planeBackup[amrex::Amrvis::NPLANES];
+  Pixmap planeBuffer[amrex::Amrvis::NPLANES]; 
+  GC planeGC[amrex::Amrvis::NPLANES];
+  
+  // Initialize arrays to None
+  for(int i = 0; i < amrex::Amrvis::NPLANES; ++i) {
+    planeBackup[i] = None;
+    planeBuffer[i] = None;
+    planeGC[i] = None;
+  }
   
 #if (BL_SPACEDIM == 3)
   // Create double buffering for additional 3D planes

--- a/ProfApp.cpp
+++ b/ProfApp.cpp
@@ -1350,7 +1350,7 @@ void ProfApp::DoRubberBanding(Widget, XtPointer client_data, XtPointer call_data
   XChangeActivePointerGrab(display, PointerMotionHintMask |
                            ButtonMotionMask | ButtonReleaseMask |
                            OwnerGrabButtonMask, cursor, CurrentTime);
-  AVXGrab avxGrab(display);
+  XSync(display, False);
 
   if(servingButton == 1) {
     if(bShiftDown) {
@@ -1378,6 +1378,7 @@ void ProfApp::DoRubberBanding(Widget, XtPointer client_data, XtPointer call_data
           rStartY = (anchorY < oldY) ? anchorY : oldY;
           XDrawRectangle(display, regionPicturePtr->PictureWindow(),
                          rbgc, rStartX, rStartY, rWidth, rHeight);
+          XSync(display, False);
         }
 
         while(XCheckTypedEvent(display, MotionNotify, &nextEvent)) {
@@ -1402,6 +1403,7 @@ void ProfApp::DoRubberBanding(Widget, XtPointer client_data, XtPointer call_data
         rStartY = (anchorY < newY) ? anchorY : newY;
         XDrawRectangle(display, regionPicturePtr->PictureWindow(),
                        rbgc, rStartX, rStartY, rWidth, rHeight);
+        XSync(display, False);
         rectDrawn = true;
 
         oldX = newX;
@@ -1410,7 +1412,6 @@ void ProfApp::DoRubberBanding(Widget, XtPointer client_data, XtPointer call_data
         break;
 
       case ButtonRelease: {
-        avxGrab.ExplicitUngrab();
 
         startX = (max(0, min(imageWidth,  anchorX))) / scale;
         startY = (max(0, min(imageHeight, anchorY))) / scale;
@@ -1512,7 +1513,6 @@ void ProfApp::DoRubberBanding(Widget, XtPointer client_data, XtPointer call_data
       break;
 
       case ButtonRelease:
-        avxGrab.ExplicitUngrab();
 
         if(saveOldX == nextEvent.xbutton.x && saveOldY == nextEvent.xbutton.y) {
           // ---- turn region off
@@ -1576,7 +1576,6 @@ void ProfApp::DoRubberBanding(Widget, XtPointer client_data, XtPointer call_data
       break;
 
       case ButtonRelease:
-        avxGrab.ExplicitUngrab();
 
         if(saveOldX == nextEvent.xbutton.x && saveOldY == nextEvent.xbutton.y) {
           // ---- turn region on

--- a/XYPlotWin.cpp
+++ b/XYPlotWin.cpp
@@ -2292,7 +2292,7 @@ void XYPlotWin::CBdoRubberBanding(Widget, XtPointer, XtPointer call_data) {
 			     ButtonPressMask | ButtonReleaseMask |
 			     PointerMotionMask | PointerMotionHintMask,
 			     zoomCursor, CurrentTime);
-    AVXGrab avxGrab(disp);
+    XSync(disp, False);
     lowX = TRANX(anchorX);
     lowY = TRANY(anchorY);
     
@@ -2325,6 +2325,7 @@ void XYPlotWin::CBdoRubberBanding(Widget, XtPointer, XtPointer call_data) {
 	  rStartY = (anchorY < oldY) ? anchorY : oldY;
 	  XDrawRectangle(disp, pWindow, rbGC, rStartX, rStartY,
 			 rWidth, rHeight);
+	  XSync(disp, False);
 	}
 	
 	// get rid of those pesky extra MotionNotify events
@@ -2341,6 +2342,7 @@ void XYPlotWin::CBdoRubberBanding(Widget, XtPointer, XtPointer call_data) {
 	rStartY = (anchorY < newY) ? anchorY : newY;
 	XDrawRectangle(disp, pWindow, rbGC, rStartX, rStartY,
 		       rWidth, rHeight);
+	XSync(disp, False);
 	rectDrawn = true;
 	
 	oldX = newX;
@@ -2349,7 +2351,6 @@ void XYPlotWin::CBdoRubberBanding(Widget, XtPointer, XtPointer call_data) {
 	break;
 	
       case ButtonRelease:
-	avxGrab.ExplicitUngrab();  // giveitawaynow
 	
 	// undraw rectangle
 	rWidth  = std::abs(oldX-anchorX);
@@ -2358,6 +2359,7 @@ void XYPlotWin::CBdoRubberBanding(Widget, XtPointer, XtPointer call_data) {
 	rStartY = (anchorY < oldY) ? anchorY : oldY;
 	XDrawRectangle(disp, pWindow, rbGC, rStartX, rStartY,
 		       rWidth, rHeight);
+	XSync(disp, False);
 	
 	highX = TRANX(newX);
 	highY = TRANY(newY);


### PR DESCRIPTION
Replace old rubber band drawing that grabbed the X server with double buffered drawing.

This allows using x11vnc or xpra to stream an interactive "remote" desktop with Amrvis.