### PR TITLE
Add a checkbox for toggling opacity in 3d redering

### DIFF
--- a/Docs/Amrvis.tex
+++ b/Docs/Amrvis.tex
@@ -294,6 +294,7 @@ of the isometric image in 3D (boxes or volumetric rendering).
 			to draw.
     \item [Autodraw]    Automatically render the image while rotating.
 			As with {\bf Draw}, the first image takes longer.
+    \item [Invert Opacity] Useful when high-density regions are outside the volume.
     \item [Trans]       Reread the transfer functions.
     \item [Lights]      Allows the user to set the rendering lighting parameters.
     \item[Light/Value]  This menu shows the volume rendering

--- a/PltApp.H
+++ b/PltApp.H
@@ -162,6 +162,7 @@ private:
   Widget wAttach, wDetachTopLevel;
 #if defined(BL_VOLUMERENDER) || defined(BL_PARALLELVOLUMERENDER)
   Widget wAutoDraw;
+  Widget wInvertOpacity;
   Widget wLWambient, wLWdiffuse, wLWspecular, wLWshiny;
   Widget wLWminOpacity, wLWmaxOpacity;
   Widget wCurrentRenderMode, wCurrentClassify;
@@ -229,7 +230,7 @@ private:
   ProjectionPicture *projPicturePtr;
   ViewTransform	viewTrans;
   bool lightingModel, showing3dRender, preClassify, lightingWindowExists;
-
+  bool invert_opacity = false;
 #endif
   
   void PltAppInit(bool bSubVolume = false);           // called by constructors
@@ -308,6 +309,7 @@ private:
   void DoRenderModeMenu(Widget, XtPointer, XtPointer);
   void DoClassifyMenu(Widget, XtPointer, XtPointer);
   void DoAutoDraw(Widget, XtPointer, XtPointer);
+  void SetInvertOpacity(Widget, XtPointer, XtPointer);
   void DoCreateLightingWindow(Widget, XtPointer, XtPointer);
   void DoDoneLightingWindow(Widget, XtPointer, XtPointer);
   void DoApplyLightingWindow(Widget, XtPointer, XtPointer);

--- a/PltApp.cpp
+++ b/PltApp.cpp
@@ -1133,6 +1133,11 @@ void PltApp::PltAppInit(bool bSubVolume) {
     XtVaCreateManagedWidget("Autodraw", xmToggleButtonGadgetClass, wMenuPulldown,
 			    XmNmnemonic, 'A', XmNset, false, NULL);
   AddStaticCallback(wAutoDraw, XmNvalueChangedCallback, &PltApp::DoAutoDraw);
+
+  wInvertOpacity =
+    XtVaCreateManagedWidget("Invert Opacity", xmToggleButtonGadgetClass, wMenuPulldown,
+			    XmNmnemonic, 'I', XmNset, false, NULL);
+  AddStaticCallback(wInvertOpacity, XmNvalueChangedCallback, &PltApp::SetInvertOpacity);
   
   wid = XtVaCreateManagedWidget("Lighting...",
 				xmPushButtonGadgetClass, wMenuPulldown,

--- a/PltApp3D.cpp
+++ b/PltApp3D.cpp
@@ -792,7 +792,7 @@ void PltApp::SetInvertOpacity(Widget, XtPointer, XtPointer) {
   VolRender *volRenderPtr = projPicturePtr->GetVolRenderPtr();
   if (volRenderPtr && volRenderPtr->GetInvertOpacity() != invert_opacity) {
     volRenderPtr->SetInvertOpacity(invert_opacity);
-    volRenderPtr->InvalidateSWFData();
+    volRenderPtr->SetTransferProperties();
     volRenderPtr->InvalidateVPData();
   }
 }

--- a/PltApp3D.cpp
+++ b/PltApp3D.cpp
@@ -782,6 +782,20 @@ void PltApp::DoAutoDraw(Widget, XtPointer, XtPointer) {
   DoExposeTransDA();
 }
 
+// -------------------------------------------------------------------
+void PltApp::SetInvertOpacity(Widget, XtPointer, XtPointer) {
+  if(XmToggleButtonGetState(wInvertOpacity)) {
+    invert_opacity = true;
+  } else {
+    invert_opacity = false;
+  }
+  VolRender *volRenderPtr = projPicturePtr->GetVolRenderPtr();
+  if (volRenderPtr && volRenderPtr->GetInvertOpacity() != invert_opacity) {
+    volRenderPtr->SetInvertOpacity(invert_opacity);
+    volRenderPtr->InvalidateSWFData();
+    volRenderPtr->InvalidateVPData();
+  }
+}
 
 // -------------------------------------------------------------------
 void PltApp::DoRenderModeMenu(Widget w, XtPointer item_no, XtPointer /*client_data*/) {

--- a/VolRender.H
+++ b/VolRender.H
@@ -92,6 +92,8 @@ class VolRender {
     void SetTransferProperties();
     void SetLighting(Real ambient, Real diffuse, Real specular, Real shiny,
 		     Real minRay, Real maxRay);
+    void SetInvertOpacity(bool a_invert_opacity) { invert_opacity = a_invert_opacity; }
+    bool GetInvertOpacity() { return invert_opacity; }
     Real GetDiffuse() { return diffuseMat; }
     Real GetAmbient() { return ambientMat; }
     Real GetSpecular() { return specularMat; }
@@ -102,6 +104,7 @@ class VolRender {
   private:
     Real diffuseMat, shinyMat, specularMat, ambientMat;
     Real vpLen, vpAspect;
+    bool invert_opacity = false;
     bool lightingModel, preClassify;
     bool bDrawAllBoxes;
     int  voxelFields;

--- a/VolRender.cpp
+++ b/VolRender.cpp
@@ -273,7 +273,7 @@ void VolRender::MakeSWFData(amrex::DataServices *dataServicesPtr,
     int grows   = gbox.length(Amrvis::XDIR);
     int gcols   = gbox.length(Amrvis::YDIR);
     //int gplanes = gbox.length(Amrvis::ZDIR);
-    
+
     int gcolsgrowstmp(gcols * grows);
     int gpgcgrtmp, gcgrowstmp;
     for(int gp(gostartp); gp <= goendp; ++gp) {
@@ -285,6 +285,9 @@ void VolRender::MakeSWFData(amrex::DataServices *dataServicesPtr,
           dat = dataPoint[gcgrowstmp + gr];
           dat = max(dat,gmin); // clip data if out of range
           dat = min(dat,gmax);
+          if (invert_opacity) {
+            dat = gmax - (dat-gmin);
+          }
           chardat = (char) (((dat - gmin) * oneOverGDiff) * cSlotsAvail);
           chardat += (char) iPaletteStart;
 	  int gprev = gostartp + goendp - gp;

--- a/VolRender.cpp
+++ b/VolRender.cpp
@@ -285,9 +285,6 @@ void VolRender::MakeSWFData(amrex::DataServices *dataServicesPtr,
           dat = dataPoint[gcgrowstmp + gr];
           dat = max(dat,gmin); // clip data if out of range
           dat = min(dat,gmax);
-          if (invert_opacity) {
-            dat = gmax - (dat-gmin);
-          }
           chardat = (char) (((dat - gmin) * oneOverGDiff) * cSlotsAvail);
           chardat += (char) iPaletteStart;
 	  int gprev = gostartp + goendp - gp;
@@ -1002,6 +999,11 @@ void VolRender::MakeDefaultTransProperties() {
 void VolRender::SetTransferProperties() {
   BL_ASSERT(palettePtr != NULL);
   density_ramp = palettePtr->GetTransferArray();
+  if (invert_opacity) {
+      for (auto& op : density_ramp) {
+	  op = float(1) - op;
+      }
+  }
   //density_ramp[palettePtr->BodyIndex()] = 0.08;
   density_ramp[palettePtr->BodyIndex()] = (float) AVGlobals::GetBodyOpacity();
   vpSetClassifierTable(vpc, DENSITY_PARAM, densityField,


### PR DESCRIPTION
By default, regions with higher density region have higher opacity. In the current implementation, there is no option to change this behavior. At least, I cannot find it. So I added a checkbox for inverting the opacity mapping. This is useful when the high-density region is outside the main volume.