### PR TITLE
Fix X11/AMReX `None` macro conflict introduced in AMReX ee287530

### DIFF
--- a/AmrVisTool.cpp
+++ b/AmrVisTool.cpp
@@ -23,6 +23,9 @@
 #include <Palette.H>
 #include <PltApp.H>
 #include <GlobalUtilities.H>
+
+// X11 defines None as 0, which conflicts with AMReX's QuoteType::None enum.
+#undef None
 #include <AMReX_ParmParse.H>
 #include <AMReX_DataServices.H>
 #include <PltAppState.H>

--- a/AmrVisTool.cpp
+++ b/AmrVisTool.cpp
@@ -4,6 +4,13 @@
 
 #include <AMReX_ParallelDescriptor.H>
 #include <AMReX_BLProfiler.H>
+#include <AMReX_ParmParse.H>
+#include <AMReX_DataServices.H>
+#include <PltAppState.H>
+#ifdef BL_USE_PROFPARSER
+#include <ProfApp.H>
+#include <AMReX_DataServices.H>
+#endif
 
 #include <stdio.h>
 #if ! (defined(BL_OSF1) || defined(BL_Darwin) || defined(BL_AIX) || defined(BL_IRIX64) || defined(BL_CYGWIN_NT) || defined(BL_CRAYX1))
@@ -23,16 +30,6 @@
 #include <Palette.H>
 #include <PltApp.H>
 #include <GlobalUtilities.H>
-
-// X11 defines None as 0, which conflicts with AMReX's QuoteType::None enum.
-#undef None
-#include <AMReX_ParmParse.H>
-#include <AMReX_DataServices.H>
-#include <PltAppState.H>
-#ifdef BL_USE_PROFPARSER
-#include <ProfApp.H>
-#include <AMReX_DataServices.H>
-#endif
 
 #ifdef BL_VOLUMERENDER
 #include <VolRender.H>


### PR DESCRIPTION
## Problem

AMReX commit ee287530 introduced `enum class QuoteType : unsigned char { None = 0, ... }`
in `AMReX_ParmParse.H`. X11's `Xlib.h` defines `#define None 0`. 

## Fix

Add a `#undef None` before `#include <AMReX_ParmParse.H>` in `AmrVisTool.cpp`, after all Amrvis/X11 headers have been included. Placing the undef earlier (e.g. alongside `#undef index`) breaks `PltApp.H`, which uses `None` as an X11
default argument value.

## Files changed

- `Amrvis/AmrVisTool.cpp` — add `#undef None` between `GlobalUtilities.H` and
  `AMReX_ParmParse.H` includes

Co-authored-by: svenjanerzakITV <s.nerzak@itv.rwth-aachen.de>